### PR TITLE
Fix `Could not find executable named "groff"` error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM gliderlabs/alpine:3.1
 MAINTAINER Xueshan Feng <sfeng@stanford.edu>
 
 RUN apk --update add \
+      groff \
       python \
       py-pip \
       jq \


### PR DESCRIPTION
by installing the missing dependency.

This fixes invoking `help` commands for me, like those:

```
docker run --rm  xueshanf/awscli aws cognito-identity help
```
