### PR TITLE
Regression fix: make Docker build run again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM gliderlabs/alpine:3.1
 MAINTAINER Xueshan Feng <sfeng@stanford.edu>
 
-RUN apk --update add 
+RUN apk --update add \ 
       less \
       groff \
       python \


### PR DESCRIPTION
by readding accidentally deleted backslash in the `Dockerfile` (https://github.com/xueshanf/docker-awscli/commit/8b1325affbd52bf1ccb95121ee27f58eeca22675)

@xueshanf Please take a look.
