### PR TITLE
Removed forced volume declaration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,3 @@ RUN apk --no-cache add \
       mkdir /root/.aws
 
 COPY get-metadata /usr/local/bin/get-metadata
-
-# Expose data volume
-VOLUME /apps


### PR DESCRIPTION
Why?

If you need a volume than you can declare it by `-v` or docker-compose. But if you do not want a volume but instead only run some short-running containers via docker run or use this CLI as base image than you are spammed with anonymous empty docker volumes.